### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   , "repository": "git://github.com/buunguyen/mongoose-migrate"
   , "bin": { "mongoose-migrate-2": "./bin/migrate" }
   , "dependencies" : {
-      "mongoose": "^4.2.0"
+      "mongoose": "^4.8.3"
     }
   , "main": "index"
   , "engines": { "node": ">= 0.8.x" }


### PR DESCRIPTION
Running migrations on: mongodb://**********************?ssl=true
Running migration with ssl on mongoose 4.2.x fails with ssl error from mongoose. Updating to 4.8.3 fixes the problem.
node_modules/mongoose-migrate/node_modules/mongoose/node_modules/mongodb/lib/server.js:235
process.nextTick(function() { throw err; })
^
Error: unable to verify the first certificate
at Error (native)
at TLSSocket.<anonymous> (_tls_wrap.js:1017:38)
at emitNone (events.js:67:13)
at TLSSocket.emit (events.js:166:7)
at TLSSocket._init.ssl.onclienthello.ssl.oncertcb.TLSSocket._finishInit (_tls_wrap.js:582:8)
at TLSWrap.ssl.onclienthello.ssl.oncertcb.ssl.onnewsession.ssl.onhandshakedone (_tls_wrap.js:424:38)