### PR TITLE
Support mongo v3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
     "name": "mongoose-migrate-2"
-  , "version": "0.2.3"
+  , "version": "0.2.4"
   , "description": "Migration framework for MongoDB"
   , "keywords": ["migrate", "migrations", "mongoose", "mongodb"]
   , "author": "Buu Nguyen <buunguyen@gmail.com>"
   , "repository": "git://github.com/buunguyen/mongoose-migrate"
   , "bin": { "mongoose-migrate-2": "./bin/migrate" }
   , "dependencies" : {
-      "mongoose": "^4.8.3"
+      "mongoose": "^5.0.0"
     }
   , "main": "index"
   , "engines": { "node": ">= 0.8.x" }


### PR DESCRIPTION
Per doc http://mongoosejs.com/docs/compatibility.html, need mongoose 5.0 for mongo server 3.6 (latest at the moment)