### PR TITLE
Fix bug padding numbers with more than 4 digits

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -185,7 +185,8 @@ var commands = {
  */
 
 function pad(n) {
-  return Array(4 - n.toString().length).join('0') + n;
+  let numberLength = n.toString().length;
+  return numberLength >= 4 ? n : Array(4 - numberLength).join('0') + n;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mongoose-migrate-2"
-  , "version": "0.2.4"
+  , "version": "0.2.5"
   , "description": "Migration framework for MongoDB"
   , "keywords": ["migrate", "migrations", "mongoose", "mongodb"]
   , "author": "Buu Nguyen <buunguyen@gmail.com>"


### PR DESCRIPTION
The incremental number that is used to generate the migration file name is limited to 4 digits. This pull request fixes this issue.